### PR TITLE
[Feat] 지난 챌린지 탭에서 챌린지 평가

### DIFF
--- a/HRHN/View/UI/Cell/ChallengeCell.swift
+++ b/HRHN/View/UI/Cell/ChallengeCell.swift
@@ -21,5 +21,6 @@ final class ChallengeCell: UITableViewCell {
         }
         .margins(.vertical, 10)
         backgroundColor = .clear
+        selectionStyle = .none
     }
 }

--- a/HRHN/View/UI/SwiftUIView/ReviewView.swift
+++ b/HRHN/View/UI/SwiftUIView/ReviewView.swift
@@ -10,17 +10,26 @@ import SwiftUI
 struct ReviewView: View {
     @ObservedObject private var viewModel: ReviewViewModel
     
+    private var titleLabel: String {
+        switch viewModel.previousTab {
+        case .addTab:
+            return "저번 챌린지는 어땠나요?"
+        case .recordTab:
+            return "이 챌린지는 어땠나요?"
+        }
+    }
+    
     init(viewModel: ReviewViewModel) {
         self.viewModel = viewModel
     }
     
     var body: some View {
         VStack(spacing: 0) {
-            Text("오늘을 시작하기 전,\n저번 챌린지를 평가하세요")
+            Text(titleLabel)
                 .font(.system(size: 25, weight: .bold))
                 .frame(maxWidth: .infinity, alignment: .leading)
             Spacer(minLength: 20)
-            Text(viewModel.previousChallenge?.content ?? "")
+            Text(viewModel.challenge.content)
                 .foregroundColor(.cellLabel)
                 .padding(20.adjusted)
                 .frame(maxWidth: .infinity)
@@ -44,7 +53,6 @@ struct ReviewView: View {
                 }
             }
             .padding(.horizontal, 15)
-            Spacer(minLength: 20)
         }
         .padding([.horizontal, .top], 20)
         .setBackgroundColor(.background)
@@ -66,6 +74,8 @@ private extension ReviewView {
     func emojiButton(_ emoji: Emoji) -> some View {
         Button {
             viewModel.selectedEmoji = emoji
+            viewModel.updateChallenge()
+            viewModel.navigate()
         } label: {
             if viewModel.selectedEmoji == emoji {
                 emojiImage(emoji)
@@ -93,7 +103,16 @@ private extension ReviewView {
 #if DEBUG
 struct ReviewView_Previews: PreviewProvider {
     static var previews: some View {
-        ReviewView(viewModel: ReviewViewModel())
+        ReviewView(viewModel: ReviewViewModel(
+            from: .addTab,
+            challenge: Challenge(
+                id: UUID(),
+                date: Date(),
+                content: "Preview",
+                emoji: .none
+            ),
+            navigationController: nil
+        ))
     }
 }
 #endif

--- a/HRHN/View/VC/RecordViewController.swift
+++ b/HRHN/View/VC/RecordViewController.swift
@@ -18,7 +18,6 @@ final class RecordViewController: UIViewController {
     private lazy var tableView: UITableView = { [weak self] in
         $0.backgroundColor = .clear
         $0.separatorStyle = .none
-        $0.allowsSelection = false
         $0.showsVerticalScrollIndicator = false
         $0.register(ChallengeCell.self, forCellReuseIdentifier: "ChallengeCell")
         $0.register(RecordHeaderView.self, forHeaderFooterViewReuseIdentifier: "RecordHeaderView")
@@ -117,6 +116,16 @@ extension RecordViewController: UITableViewDelegate {
             return UIView()
         }
         return headerView
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let reviewVC = ReviewViewController(viewModel: ReviewViewModel(
+            from: .recordTab,
+            challenge: viewModel.challenges.value[indexPath.row],
+            navigationController: self.navigationController
+        ))
+        reviewVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(reviewVC, animated: true)
     }
 
 }

--- a/HRHN/View/VC/ReviewViewController.swift
+++ b/HRHN/View/VC/ReviewViewController.swift
@@ -19,16 +19,6 @@ final class ReviewViewController: UIViewController {
     
     private lazy var reviewViewHC = UIHostingController(rootView: ReviewView(viewModel: viewModel))
     
-    private lazy var nextButton: UIFullWidthButton = {
-        $0.title = "다음"
-        $0.action = UIAction { _ in
-            self.viewModel.updateChallenge()
-            self.navigationController?.pushViewController(AddViewController(viewModel: AddViewModel()), animated: true)
-        }
-        $0.isEnabled = false
-        return $0
-    }(UIFullWidthButton())
-    
     // MARK: LifeCycle
     
     init(viewModel: ReviewViewModel) {
@@ -53,16 +43,7 @@ final class ReviewViewController: UIViewController {
 private extension ReviewViewController {
     
     func bind() {
-        viewModel.$selectedEmoji
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                if $0 == .none {
-                    self?.nextButton.isEnabled = false
-                } else {
-                    self?.nextButton.isEnabled = true
-                }
-            }
-            .store(in: &cancelBag)
+
     }
 }
 
@@ -73,17 +54,12 @@ private extension ReviewViewController {
     func setUI() {
         view.backgroundColor = .background
         
-        view.addSubview(nextButton)
-        nextButton.snp.makeConstraints {
-            $0.horizontalEdges.bottom.equalTo(view.safeAreaLayoutGuide).inset(20)
-        }
-        
         addChild(reviewViewHC)
         view.addSubview(reviewViewHC.view)
         reviewViewHC.didMove(toParent: self)
         reviewViewHC.view.snp.makeConstraints {
             $0.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide)
-            $0.bottom.equalTo(nextButton.snp.top)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(120)
         }
     }
     
@@ -109,7 +85,19 @@ final class ReviewViewNavigationPreview: UIViewController {
     
     func setButton() {
         button.action = UIAction { _ in
-            self.navigationController?.pushViewController(ReviewViewController(viewModel: ReviewViewModel()), animated: true)
+            self.navigationController?.pushViewController(
+                ReviewViewController(viewModel: ReviewViewModel(
+                    from: .addTab,
+                    challenge: Challenge(
+                        id: UUID(),
+                        date: Date(),
+                        content: "Preview",
+                        emoji: .none
+                    ),
+                    navigationController: self.navigationController
+                )),
+                animated: true
+            )
         }
     }
     

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -108,7 +108,7 @@ extension TodayViewController {
     }
     
     @objc func addButtonDidTap(_ sender: UIButton) {
-        viewModel.pushToAdd(with: self.navigationController)
+        viewModel.addButtonDidTap(navigationController: navigationController)
     }
     
     @objc private func cardDidTap(tapGestureRecognizer: UITapGestureRecognizer) {

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -108,15 +108,7 @@ extension TodayViewController {
     }
     
     @objc func addButtonDidTap(_ sender: UIButton) {
-        if viewModel.isPreviousChallengeExist() {
-            let reviewVC = ReviewViewController(viewModel: ReviewViewModel())
-            reviewVC.hidesBottomBarWhenPushed = true
-            navigationController?.pushViewController(reviewVC, animated: true)
-        } else {
-            let addVC = AddViewController(viewModel: AddViewModel())
-            addVC.hidesBottomBarWhenPushed = true
-            navigationController?.pushViewController(addVC, animated: true)
-        }
+        viewModel.pushToAdd(with: self.navigationController)
     }
     
     @objc private func cardDidTap(tapGestureRecognizer: UITapGestureRecognizer) {

--- a/HRHN/ViewModel/ReviewViewModel.swift
+++ b/HRHN/ViewModel/ReviewViewModel.swift
@@ -6,33 +6,46 @@
 //
 
 import Foundation
+import UIKit
 
 final class ReviewViewModel: ObservableObject {
     
-    @Published var previousChallenge: Challenge?
-    @Published var selectedEmoji: Emoji = .none
-    
-    private let coreDataManager = CoreDataManager.shared
-    
-    init() {
-        fetchPreviousChallenge()
+    enum Tab {
+        case addTab
+        case recordTab
     }
     
-    func fetchPreviousChallenge() {
-        let challenges = coreDataManager.getChallenges()
-        if challenges.count > 0 {
-            self.previousChallenge = challenges[0]
-        }
+    @Published var selectedEmoji: Emoji
+    
+    private let coreDataManager = CoreDataManager.shared
+    private let navigationController: UINavigationController?
+    
+    let challenge: Challenge
+    let previousTab: Tab
+    
+    init(from previousTab: Tab, challenge: Challenge, navigationController: UINavigationController?) {
+        self.previousTab = previousTab
+        self.challenge = challenge
+        self.navigationController = navigationController
+        self.selectedEmoji = challenge.emoji
     }
     
     func updateChallenge() {
-        guard let previousChallenge else { return }
         let updatedChallenge = Challenge(
-            id: previousChallenge.id,
-            date: previousChallenge.date,
-            content: previousChallenge.content,
+            id: challenge.id,
+            date: challenge.date,
+            content: challenge.content,
             emoji: selectedEmoji
         )
         coreDataManager.updateChallenge(updatedChallenge)
+    }
+    
+    func navigate() {
+        switch previousTab {
+        case .addTab:
+            navigationController?.pushViewController(AddViewController(viewModel: AddViewModel()), animated: true)
+        case .recordTab:
+            navigationController?.popToRootViewController(animated: true)
+        }
     }
 }

--- a/HRHN/ViewModel/TodayViewModel.swift
+++ b/HRHN/ViewModel/TodayViewModel.swift
@@ -50,4 +50,21 @@ final class TodayViewModel {
             return true
         }
     }
+    
+    func pushToAdd(with navigationController: UINavigationController?) {
+        let challenges = coreDataManager.getChallenges()
+        if challenges.count > 0 && challenges[0].emoji == .none {
+            let reviewVC = ReviewViewController(viewModel: ReviewViewModel(
+                from: .addTab,
+                challenge: challenges[0],
+                navigationController: navigationController
+            ))
+            reviewVC.hidesBottomBarWhenPushed = true
+            navigationController?.pushViewController(reviewVC, animated: true)
+        } else {
+            let addVC = AddViewController(viewModel: AddViewModel())
+            addVC.hidesBottomBarWhenPushed = true
+            navigationController?.pushViewController(addVC, animated: true)
+        }
+    }
 }

--- a/HRHN/ViewModel/TodayViewModel.swift
+++ b/HRHN/ViewModel/TodayViewModel.swift
@@ -24,15 +24,6 @@ final class TodayViewModel {
             self.todayChallenge = Observable(nil)
         }
     }
-
-    func isPreviousChallengeExist() -> Bool {
-        let challenges = coreDataManager.getChallenges()
-        if challenges.count > 0 && challenges[0].emoji == .none {
-            return true
-        } else {
-            return false
-        }
-    }
     
     func requestNotificationAuthorization() {
         let authOptions = UNAuthorizationOptions(arrayLiteral: .alert, .badge, .sound)

--- a/HRHN/ViewModel/TodayViewModel.swift
+++ b/HRHN/ViewModel/TodayViewModel.swift
@@ -42,7 +42,7 @@ final class TodayViewModel {
         }
     }
     
-    func pushToAdd(with navigationController: UINavigationController?) {
+    func addButtonDidTap(navigationController: UINavigationController?) {
         let challenges = coreDataManager.getChallenges()
         if challenges.count > 0 && challenges[0].emoji == .none {
             let reviewVC = ReviewViewController(viewModel: ReviewViewModel(


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #72 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- '어제 챌린지만 따로 평가'에 해당하는 작업입니다.
    - 원래는 챌린지 추가 버튼을 눌렀을 때 평가만 하고 탈출 가능하게 하려고 했으나 '추가' 버튼을 눌렀는데 평가만 하고 나갈 수 있게 해주는건 뭔가 이상하고 불필요하다고 생각해서 평가만 하고 싶으면 지난 챌린지 탭에서 하도록 만들었습니다.
- ReviewViewController, ReviewViewModel을 재사용 가능하게 수정했습니다.
- 지난 챌린지 탭에서 챌린지를 클릭하면 평가 수정 가능하도록 기능을 추가했습니다.
- ReviewVC에서 FullWidthButton 제거한 디자인 수정사항을 반영했습니다.

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
<img src="https://user-images.githubusercontent.com/75792767/211720847-e7c83a5b-cfbc-4656-8973-a2ec583bb77a.gif" width="250">

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 내비게이션로직도 뷰모델에서 하기 위해 뷰모델에 UINavigationController를 전달했습니다.
    - SwiftUI에서 emojiButton을 누르면 바로 내비게이션되도록 해야 돼서 이렇게 했습니다.
    - 본 적 없는 방식이라 문제가 없을지는 모르겠습니다,,,
- ReviewViewModel에 이전 화면이 뭐였는지 정보를 담는 Tab enum을 만들어서 분기 처리를 했습니다.
- ReviewViewModel이 초기화될 때 Challenge를 받도록 했습니다.

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
