### PR TITLE
[Fix] 뷰컨이 deinit이 안되는 이슈 수정

### DIFF
--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -122,7 +122,7 @@ final class AddViewController: UIViewController {
         setLayout()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         addChallengeTextView.becomeFirstResponder()
     }
 }

--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -54,12 +54,12 @@ final class AddViewController: UIViewController {
         return $0
     }(UIView())
     
-    private lazy var doneButton: UIFullWidthButton = {
+    private lazy var doneButton: UIFullWidthButton = { [weak self] in
         $0.title = "완료"
         $0.isOnKeyboard = true
         $0.isEnabled = false
         $0.action = UIAction { _ in
-            self.doneButtonDidTap()
+            self?.doneButtonDidTap()
         }
         return $0
     }(UIFullWidthButton())
@@ -75,7 +75,7 @@ final class AddViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private lazy var addChallengeTextView: UITextView = {
+    private lazy var addChallengeTextView: UITextView = { [weak self] in
         $0.attributedText = NSAttributedString(
             string: " ",
             attributes: mainTextAttributes

--- a/HRHN/View/VC/ModifyViewController.swift
+++ b/HRHN/View/VC/ModifyViewController.swift
@@ -54,12 +54,12 @@ final class ModifyViewController: UIViewController {
         return $0
     }(UIView())
     
-    private lazy var doneButton: UIFullWidthButton = {
+    private lazy var doneButton: UIFullWidthButton = { [weak self] in
         $0.title = "완료"
         $0.isOnKeyboard = true
         $0.isEnabled = false
         $0.action = UIAction { _ in
-            self.doneButtonDidTap()
+            self?.doneButtonDidTap()
         }
         return $0
     }(UIFullWidthButton())
@@ -76,7 +76,7 @@ final class ModifyViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private lazy var modifyChallengeTextView: UITextView = {
+    private lazy var modifyChallengeTextView: UITextView = { [weak self] in
         $0.attributedText = NSAttributedString(
             string: viewModel.currentChallenge?.content ?? "",
             attributes: mainTextAttributes

--- a/HRHN/View/VC/ModifyViewController.swift
+++ b/HRHN/View/VC/ModifyViewController.swift
@@ -123,7 +123,7 @@ final class ModifyViewController: UIViewController {
         setLayout()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
         modifyChallengeTextView.becomeFirstResponder()
     }
 }

--- a/HRHN/View/VC/OnBoarding/OnBoardingPageViewController.swift
+++ b/HRHN/View/VC/OnBoarding/OnBoardingPageViewController.swift
@@ -24,10 +24,10 @@ class OnBoardingPageViewController: UIPageViewController {
         return $0
     }(UIButton())
     
-    private lazy var nextButton: UIFullWidthButton = {
+    private lazy var nextButton: UIFullWidthButton = { [weak self] in
         $0.title = "시작하기"
         $0.action = UIAction { _ in
-            self.nextButtonDidTap()
+            self?.nextButtonDidTap()
         }
         return $0
     }(UIFullWidthButton())

--- a/HRHN/View/VC/RecordViewController.swift
+++ b/HRHN/View/VC/RecordViewController.swift
@@ -39,8 +39,6 @@ final class RecordViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.delegate = self
-        tableView.dataSource = self
         setUI()
         setNavigationBar()
     }

--- a/HRHN/View/VC/SettingViewController.swift
+++ b/HRHN/View/VC/SettingViewController.swift
@@ -46,8 +46,6 @@ final class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.delegate = self
-        tableView.dataSource = self
         setUI()
         setNavigationBar()
     }

--- a/HRHN/View/VC/SettingViewController.swift
+++ b/HRHN/View/VC/SettingViewController.swift
@@ -110,11 +110,11 @@ extension SettingViewController: UITableViewDataSource {
             for: indexPath
         ) as? SettingCell else { return UITableViewCell() }
         cell.configureCell(with: target)
-        cell.setAlertHandler = {
-            self.viewModel.setNotAllowed(with: $0)
+        cell.setAlertHandler = { [weak self] in
+            self?.viewModel.setNotAllowed(with: $0)
         }
-        cell.setTimeHandler = {
-            self.viewModel.setNotiTime(with: $0)
+        cell.setTimeHandler = { [weak self] in
+            self?.viewModel.setNotiTime(with: $0)
         }
         return cell
     }


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #75 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 순환 참조를 막기 위해 UIFullWidthButton, SettingVC에 [weak self] 추가
    - 이슈 #75 에 올린 현상의 이유가 순환참조임을 발견해서 해결했습니다.
- becomeFirstResponder를 viewWillAppear에서 viewDidAppear로 이동
    - [becomeFirstResponder 공식문서](https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder)
    <img width="690" alt="image" src="https://user-images.githubusercontent.com/75792767/212528370-91c321ba-0a20-49a9-95e3-cf76db2762fd.png">

    - [viewWillAppear 공식문서](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621510-viewwillappear)
    <img width="704" alt="image" src="https://user-images.githubusercontent.com/75792767/212528395-e395f82d-4de7-4587-8329-ff6eac671da2.png">

    - becomeFirstResponder는 뷰 계층에 올라간 뷰에서만 불러야 하는데, viewWillAppear는 뷰 계층에 올라가기 전에 호출되기 때문에 사용하면 안된다.
    - 현재 viewWillAppear에서 becomeFirstResponder를 호출하여 애니메이션이 버벅이는 현상이 나타남.
    - 키보드 나타나는 속도가 느려진게 불편하긴 하지만 공식문서에서 하지 말라니까... 말 들어야겠죠?

- UITableView를 사용하는 뷰컨에서 delegate를 `$0.delegate = self`와 viewDidLoad 두 곳에서 중복으로 할당한 부분 수정

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- [하루하나 개발일지 - deinit 안되는거 해결하기](https://www.notion.so/avery-in-ada/deinit-55f4126e265848e281a986d393501e39)

## Checklist
- [ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
- [ ] final, private 제대로 넣었는지 확인
