### PR TITLE
[FIX] 알림 삭제 버그 수정

### DIFF
--- a/HRHN/View/VC/SettingViewController.swift
+++ b/HRHN/View/VC/SettingViewController.swift
@@ -109,7 +109,7 @@ extension SettingViewController: UITableViewDataSource {
         ) as? SettingCell else { return UITableViewCell() }
         cell.configureCell(with: target)
         cell.setAlertHandler = { [weak self] in
-            self?.viewModel.setNotAllowed(with: $0)
+            self?.viewModel.setNotiAllowed(with: $0)
         }
         cell.setTimeHandler = { [weak self] in
             self?.viewModel.setNotiTime(with: $0)

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -87,6 +87,7 @@ final class TodayViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         viewModel.requestNotificationAuthorization()
+        viewModel.removeOutdatedNotifications()
         setNavigationBar()
         setUI()
     }

--- a/HRHN/ViewModel/SettingViewModel.swift
+++ b/HRHN/ViewModel/SettingViewModel.swift
@@ -80,7 +80,7 @@ final class SettingViewModel: ObservableObject {
     
     init() {}
 
-    func setNotAllowed(with: Bool) {
+    func setNotiAllowed(with: Bool) {
         UserDefaults.isNotiAllowed = with
         if UserDefaults.isNotiAllowed == false {
             removeNotification()
@@ -118,7 +118,7 @@ final class SettingViewModel: ObservableObject {
     }
     
     private func removeNotification() {
-        center.removeDeliveredNotifications(withIdentifiers: ["dailyAlert"])
+        center.removeAllPendingNotificationRequests()
     }
 
 }

--- a/HRHN/ViewModel/TodayViewModel.swift
+++ b/HRHN/ViewModel/TodayViewModel.swift
@@ -34,6 +34,10 @@ final class TodayViewModel {
         }
     }
     
+    func removeOutdatedNotifications() {
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    }
+    
     func isTodayChallengeExist() -> Bool {
         if todayChallenge.value == nil {
             return false


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- Closes #78 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 알림이 제대로 삭제가 안되었던 버그를 수정했습니다.



<img width="538" alt="스크린샷 2023-01-19 오후 10 55 36" src="https://user-images.githubusercontent.com/63157395/213460694-1e9e22ad-9ebc-4946-8516-f2f4e25ae0bc.png">

deliveredNotification 을 삭제하는 것에서 PendingNotificationRequest를 삭제하는 것으로 수정했습니다.
저는 둘이 같은 건 줄 알았는데, 차이가 있더라구요.
저희가 매일 알림을 보내는 (스케줄링알람) 이지않습니까? 이부분에 있는 알람들은 다 pending 이랑 연관이 된걸로 공식문서에서 확인이 되어서 바꿔보니 잘 작동되는 것으로 보아 다르더라구요! 

![스크린샷 2023-01-19 오후 10 56 29](https://user-images.githubusercontent.com/63157395/213460893-1e7b0fd9-ea29-4499-9e32-18d9f271e54e.png)

결론
- delivered =>  이미 전달된 알람
- pending => 전달은 안 되었으나 스케줄에 등록된 알람!

단어 해석이 notificationcenter기준이 아니라 유저 기준입니다

그래서 수정하는 김에 든 생각이 아 그럼 지금까지 다쓴 알람이 쌓여있다는 거네?? 라는 인사이트 💡 아닌 인사이트를 얻어서
TodayVC viewdidload, 앱진입점에서 한번씩 다쓴 알람을 삭제하도록 함수를 하나 만들어서 추가해주었습니다.

420a36af967aeefbdb649028ad36580306ed876c


## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->


## Reference
<!-- 참고한 자료를 작성해주세요 -->
- https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SchedulingandHandlingLocalNotifications.html
- https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649517-removependingnotificationrequest

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
