### PR TITLE
[Hotfix] 텍스트 오류 수정

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -812,7 +812,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HRHN.HRHN.LockscreenWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -840,7 +840,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HRHN.HRHN.LockscreenWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -990,7 +990,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HRHN.HRHN;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1027,7 +1027,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HRHN.HRHN;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/HRHN/Localization/en.lproj/Localizable.strings
+++ b/HRHN/Localization/en.lproj/Localizable.strings
@@ -12,8 +12,8 @@
 
 /* LockScreen */
 "lock-title" = "Challenge of The day";
-"lock-desc" = "Add challenge of the day";
-"lock-placeholder" = "Check challenge of the day";
+"lock-desc" = "Check challenge of the day";
+"lock-placeholder" = "Add challenge of the day";
 
 /* 탭 */
 "tab-today" = "Today";

--- a/HRHN/Localization/ko.lproj/Localizable.strings
+++ b/HRHN/Localization/ko.lproj/Localizable.strings
@@ -12,8 +12,8 @@
 
 /* LockScreen */
 "lock-title" = "오늘의 챌린지";
-"lock-desc" = "오늘의 챌린지를 등록하세요!";
-"lock-placeholder" = "오늘의 챌린지를 확인합니다.";
+"lock-desc" = "오늘의 챌린지를 확인합니다.";
+"lock-placeholder" = "오늘의 챌린지를 등록하세요!";
 
 /* 탭 */
 "tab-today" = "오늘의 챌린지";

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -17,7 +17,7 @@ struct Provider: TimelineProvider {
         if todayChallenge.count > 0 {
             return todayChallenge[0].content
         } else {
-            return I18N.lockPlaceholder
+            return I18N.lockDesc
         }
     }
     
@@ -80,7 +80,7 @@ struct LockscreenWidget: Widget {
             LockscreenWidgetEntryView(entry: entry)
         }
         .configurationDisplayName(I18N.lockTitle)
-        .description(I18N.lockDesc)
+        .description(I18N.lockPlaceholder)
         .supportedFamilies([
             .accessoryRectangular
         ])

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -17,7 +17,7 @@ struct Provider: TimelineProvider {
         if todayChallenge.count > 0 {
             return todayChallenge[0].content
         } else {
-            return I18N.lockDesc
+            return I18N.lockPlaceholder
         }
     }
     
@@ -80,7 +80,7 @@ struct LockscreenWidget: Widget {
             LockscreenWidgetEntryView(entry: entry)
         }
         .configurationDisplayName(I18N.lockTitle)
-        .description(I18N.lockPlaceholder)
+        .description(I18N.lockDesc)
         .supportedFamilies([
             .accessoryRectangular
         ])


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- Closes #82

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
1.  텍스트 두개 위치 변경되어있었음 
- => 변수 선언 위치 switch!


2. 하는김에 버전업 및 widget이랑 메인앱이랑 버전이 안맞아서 뜨는 경고 해결 (아래 에러가 떠서 버전 맞춤)
> warning build: The CFBundleShortVersionString of an app extension ('1.0') must match that of its containing parent app ('1.0.2').



<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/63157395/213904397-b7ac2213-6183-4790-aea4-f64087b84410.png" width="250">|<img src="https://user-images.githubusercontent.com/63157395/213904389-aaf7c381-8fb5-4d3f-8298-1c8cb2fe08f6.png" width="250"> |

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

새복많!


## Reference
<!-- 참고한 자료를 작성해주세요 -->
https://medium.com/@michaelmavris/how-to-synchronize-versions-and-build-numbers-across-different-targets-96683482afdc


## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
